### PR TITLE
Add a new option '--dryrun'

### DIFF
--- a/report.py
+++ b/report.py
@@ -41,16 +41,21 @@ def format_message(config, cost, forecast):
     return template.format(year=today.year, month=today.month, day=today.day,
                            cost=cost, forecast=forecast)
 
-def main(aws_profile_name = "default"):
+def main(aws_profile_name = "default", dryrun=False):
     config = load_config()
     cost, forecast = get_monthly_cost(config, aws_profile_name)
     message = format_message(config, cost, forecast)
-    send_message(config, message)
+    if dryrun:
+        print(message)
+    else:
+        send_message(config, message)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--aws-profile", type=str, default="default",
         help="AWS profile name. Default: 'default'.")
+    parser.add_argument("--dryrun", action='store_true',
+        help="For debug. Print the message to stdout.")
     args = parser.parse_args()
 
-    main(args.aws_profile)
+    main(args.aws_profile, dryrun=args.dryrun)


### PR DESCRIPTION
You can use this option as follows:

    $ python3 report.py --dryrun

This is very useful for development. You can check the content of the notification message without actually posting it to Zulip.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>